### PR TITLE
Update Make.php

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -1571,8 +1571,8 @@ class Make
         $this->stdTot->vDesc += (float) $std->vDesc;
         $this->stdTot->vOutro += (float) $std->vOutro;
         
-        $cean = !empty($std->cEAN) ? trim(strtoupper($std->cEAN)) : '';
-        $ceantrib = !empty($std->cEANTrib) ? trim(strtoupper($std->cEANTrib)) : '';
+        $cean = !empty($std->cEAN) ? trim(strtoupper($std->cEAN)) : 'SEM GTIN';
+        $ceantrib = !empty($std->cEANTrib) ? trim(strtoupper($std->cEANTrib)) : 'SEM GTIN';
         
         $identificador = 'I01 <prod> - ';
         $prod = $this->dom->createElement("prod");


### PR DESCRIPTION
Seguindo a docimentação da seguinte [http://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=T7PfUOHhMD4=](NT), caso o GTIN seja enviado vazio a tag não pode mais ser <cEAN /> e sim <cEAN>SEM GTIN</cEAN>